### PR TITLE
Disable  cursorFollowMouse during 'normal' sub battle phase

### DIFF
--- a/SRPG_MouseOperation_MZ.js
+++ b/SRPG_MouseOperation_MZ.js
@@ -327,7 +327,7 @@ Input.update = function() {
 };
 
 //=============================================================================
-// TouchInput
+// MouseInput
 //=============================================================================
 $.TouchInput_onMouseMove = TouchInput._onMouseMove;
 TouchInput._onMouseMove = function(event) {
@@ -335,6 +335,15 @@ TouchInput._onMouseMove = function(event) {
   this._mouseX = Graphics.pageToCanvasX(event.pageX);
   this._mouseY = Graphics.pageToCanvasY(event.pageY);
   Graphics.setHiddenPointer(false);
+};
+
+//=============================================================================
+// TouchInput
+//=============================================================================
+$.TouchInput_onTouchStart = TouchInput._onTouchStart;
+TouchInput._onTouchStart = function(event) {
+    $.TouchInput_onTouchStart.call(this, event);
+    Graphics.setHiddenPointer(true);
 };
 
 TouchInput.atLeftBorder = function(){


### PR DESCRIPTION
Hi, Mr. Takumi Ariake.
Please review this and make adjustments if necessary.

By default, if the parameters cursorFollowMouse = 'true', and isWheelPrevNext = 'true', the mouse wheel function will be disrupted because the cursor (player) will always follow the position of the mouse pointer. With this patch, as long as the condition _isBattlePhase = 'actor_phase' and the _isSubBattlePhase = 'normal', the function cursorFollowMouse = 'true' will remain 'false'.

My patch hasn't solved the problem where at the beginning of _isBattlePhase = 'actor_phase' and _isSubBattlePhase = 'actor_target' there was a brief moment where the cursor was switching between following the mouse pointer position or following the actor position.

In terms of user experience, this does not look good. But it seems that in the section you commented on code lines 434 - 470 there is a function to solve this problem.

This plugin also still has a bug, when using touch after using a mouse, the cursorFollowMouse function remains 'true' so that the cursor will jump repeatedly between the position of the selected actor and the current mouse pointer position (tested with a laptop that has a touchscreen feature), while a similar bug is not found if using a keyboard.

Thank you.