### PR TITLE
Make the cursor always stay on top of any object

### DIFF
--- a/SRPG_core_MZ.js
+++ b/SRPG_core_MZ.js
@@ -5835,6 +5835,7 @@ Sprite_SrpgMoveTile.prototype.constructor = Sprite_SrpgMoveTile;
             var characterIndex = 0;
             this.setImage(characterName, characterIndex);
             this._followers.refresh();
+	    this.setPriorityType(2)
         } else {
             _SRPG_Game_Player_refresh.call(this);
         }


### PR DESCRIPTION
By adding `this.setPriorityType(2)` keeps the cursor always on top of any object and is not affected by the tile tag.
This way, the cursor appears and acts like a cursor.