### PR TITLE
Fix touch input, wheel, and auto target bugs

### DIFF
--- a/SRPG_MouseOperation_MZ.js
+++ b/SRPG_MouseOperation_MZ.js
@@ -316,6 +316,45 @@ Game_Map.prototype.scrollDownRight = function(distance) {
     this.scrollRight(distance);
 };
 
+
+//=============================================================================
+// Update setHiddenPointer for some battlePhase & subBattlePhase
+//=============================================================================
+
+// setHiddenPointer in the beginning of actor turn
+$.srpgStartActorTurn = Game_System.prototype.srpgStartActorTurn;
+Game_System.prototype.srpgStartActorTurn = function() {
+    $.srpgStartActorTurn.call(this);
+    Graphics.setHiddenPointer(true);
+};
+
+// setHiddenPointer after selecting any command
+// I don't know how to prevent Graphics.setHiddenPointer(false); in $.TouchInput_onMouseMove to be executed until the cursor really arrived to target
+$.startActorTargetting = Scene_Map.prototype.startActorTargetting;
+Scene_Map.prototype.startActorTargetting = function() {
+    $.startActorTargetting.call(this);
+    Graphics.setHiddenPointer(true);
+};
+
+// setHiddenPointer after any action
+// I don't know how to prevent Graphics.setHiddenPointer(false); in $.TouchInput_onMouseMove to be executed until the cursor really arrived to target
+$.srpgAfterAction = Scene_Map.prototype.srpgAfterAction;
+Scene_Map.prototype.srpgAfterAction = function() {
+    $.srpgAfterAction.call(this);
+    if ($gameSystem.isBattlePhase() === 'actor_phase') {
+        Graphics.setHiddenPointer(true);
+    }
+};
+
+
+/* It seems this block of code can be used for Graphics.setHiddenPointer(true); in some subBattlePhase
+$.srpgControlPhase = Scene_Map.prototype.srpgControlPhase;
+Scene_Map.prototype.srpgControlPhase = function() {
+    $.srpgControlPhase.call(this);
+    // additional function here    
+};
+*/
+
 //=============================================================================
 // Input
 //=============================================================================
@@ -327,7 +366,7 @@ Input.update = function() {
 };
 
 //=============================================================================
-// TouchInput
+// MouseInput
 //=============================================================================
 $.TouchInput_onMouseMove = TouchInput._onMouseMove;
 TouchInput._onMouseMove = function(event) {
@@ -335,6 +374,40 @@ TouchInput._onMouseMove = function(event) {
   this._mouseX = Graphics.pageToCanvasX(event.pageX);
   this._mouseY = Graphics.pageToCanvasY(event.pageY);
   Graphics.setHiddenPointer(false);
+};
+
+$.TouchInput_onWheel = TouchInput._onWheel;
+TouchInput._onWheel = function(event) {
+    $.TouchInput_onWheel.call(this, event);
+    if ($gameSystem.isSRPGMode()) {
+        Graphics.setHiddenPointer(true);
+    }
+};
+
+
+// Note for Mr Takumi Ariake
+// I created the initial function for $.TouchInput_onLeftButtonDown, where a left mouse click will make the mouse pointer to reappear.
+// But I haven't found a way to make the mouse pointer reappear right above the event where the current cursor(player) position is
+//  and directly select that event to enter the next subbattlephase.
+// This is the function used by SRPG Studio software.
+
+/* The function
+$.TouchInput_onLeftButtonDown = TouchInput._onLeftButtonDown;
+TouchInput._onLeftButtonDown = function(event) {
+    $.TouchInput_onLeftButtonDown.call(this, event);
+    if ($gameSystem.isSRPGMode()) {
+        Graphics.setHiddenPointer(false);
+    }
+};
+*/
+
+//=============================================================================
+// TouchInput
+//=============================================================================
+$.TouchInput_onTouchStart = TouchInput._onTouchStart;
+TouchInput._onTouchStart = function(event) {
+    $.TouchInput_onTouchStart.call(this, event);
+    Graphics.setHiddenPointer(true);
 };
 
 TouchInput.atLeftBorder = function(){


### PR DESCRIPTION
This patch fixes 3 bugs:

1. The cursorFollowMouse prevent mouse wheel for selecting next/previous actor properly;
2. The cursorFollowMouse didn't disabled during touch input, since touch input only changes the mouse cursor to none, but does not make Graphics.setHiddenPointer(false);
3. The cursorFollowMouse prevent the auto target to function properly.

I made additional comments about the functions that I wanted to implement, but could not due to my lack of knowledge and skills.

My approach my be not the most efficient one, so please review and make changes if necessary.