### PR TITLE
Fix issue in Window_ActorCommand.prototype.updatePlacement

### DIFF
--- a/SRPG_core_MZ.js
+++ b/SRPG_core_MZ.js
@@ -8737,9 +8737,8 @@ Sprite_SrpgMoveTile.prototype.constructor = Sprite_SrpgMoveTile;
         } else {
             var eventY = Graphics.height - 160;
         }
-        this.y = Math.max(eventY - this.windowHeight(), 0);
+        this.y = Math.max(eventY - this.windowHeight() - offsetY, 0 - offsetY);
     };
-
 //====================================================================
 // ●Window_SrpgBattle
 //====================================================================

--- a/SRPG_core_MZ.js
+++ b/SRPG_core_MZ.js
@@ -8729,11 +8729,11 @@ Sprite_SrpgMoveTile.prototype.constructor = Sprite_SrpgMoveTile;
     // アクターコマンドの表示位置を調節する
     Window_ActorCommand.prototype.updatePlacement = function() {
         this.height = this.windowHeight();
-        this.x = Math.max($gameTemp.activeEvent().screenX() - $gameMap.tileWidth() / 2 - this.width, 0);
-        if ($gameTemp.activeEvent().screenY() < Graphics.boxHeight - 160) {
+        this.x = Math.min(Math.max($gameTemp.activeEvent().screenX() - $gameMap.tileWidth() / 2 - this.width, 0), Graphics.width - (this.width*2+48));
+        if ($gameTemp.activeEvent().screenY() < Graphics.height - 160) {
             var eventY = $gameTemp.activeEvent().screenY();
         } else {
-            var eventY = Graphics.boxHeight - 160;
+            var eventY = Graphics.height - 160;
         }
         this.y = Math.max(eventY - this.windowHeight(), 0);
     };

--- a/SRPG_core_MZ.js
+++ b/SRPG_core_MZ.js
@@ -8729,7 +8729,9 @@ Sprite_SrpgMoveTile.prototype.constructor = Sprite_SrpgMoveTile;
     // アクターコマンドの表示位置を調節する
     Window_ActorCommand.prototype.updatePlacement = function() {
         this.height = this.windowHeight();
-        this.x = Math.min(Math.max($gameTemp.activeEvent().screenX() - $gameMap.tileWidth() / 2 - this.width, 0), Graphics.width - (this.width*2+48));
+        var offsetX = (Graphics.width - Graphics.boxWidth) / 2;
+        var offsetY = (Graphics.height - Graphics.boxHeight) / 2;
+        this.x = Math.max($gameTemp.activeEvent().screenX() - $gameMap.tileWidth() / 2 - this.width - offsetX, 0 - offsetX);
         if ($gameTemp.activeEvent().screenY() < Graphics.height - 160) {
             var eventY = $gameTemp.activeEvent().screenY();
         } else {


### PR DESCRIPTION
Because the previous method uses Graphics.boxWidth to calculate the position of Window_ActorCommand, it becomes problematic when the Screen Area is different from the UI Area.

This simple patch tries to solve `Window_ActorCommand` appearance issue, although I'm not sure if my approach is the right one.

This also solve one of these issues.
https://github.com/Ohisama-Craft/SRPG_GearMZ/issues/12